### PR TITLE
chore(settings): manage main protection via Rulesets, allow merge commits

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -6,7 +6,7 @@
 
 repository:
   allow_squash_merge: true
-  allow_merge_commit: false
+  allow_merge_commit: true
   allow_rebase_merge: true
   delete_branch_on_merge: true
   allow_update_branch: true
@@ -43,19 +43,9 @@ labels:
     color: ffffff
     description: This will not be worked on
 
-branches:
-  - name: main
-    protection:
-      # Solo maintainer repo — keep review enforcement off so the owner can
-      # still merge without requiring another reviewer. Switch to a non-null
-      # value once a second collaborator joins.
-      required_pull_request_reviews: null
-      required_status_checks:
-        strict: true
-        # Populate with exact workflow job names once CI job contexts are
-        # stable. Leave empty for now so the rule does not block merges
-        # before Probot first applies it.
-        contexts: []
-      enforce_admins: false
-      required_linear_history: true
-      restrictions: null
+# Branch protection is managed via GitHub Rulesets (`main-protection`),
+# not by this Probot settings file. The repository-wide ruleset is
+# canonically defined in agentic-workspace at:
+#   .github-templates/rulesets/main-protection.json
+# and applied via:
+#   ./scripts/apply-ruleset.sh <owner/repo>


### PR DESCRIPTION
Migrate main branch protection from Probot Settings App (legacy branch protection)
to GitHub Rulesets (`main-protection`).

- Branch protection canonically defined in agentic-workspace/.github-templates/rulesets/main-protection.json.
- Probot Settings App now manages only repo settings + labels.
- `allow_merge_commit` enabled so `develop -> main` release can use merge commits.

This change is part of the Git Flow migration: `fix/* -> develop -> main`.