### PR TITLE
fix(cli): summarize preview bootstrap compile

### DIFF
--- a/crates/ferritex-cli/src/main.rs
+++ b/crates/ferritex-cli/src/main.rs
@@ -246,6 +246,27 @@ fn print_compile_success_summary(
     }
 }
 
+fn print_preview_initial_compile_success_summary(command: &CompileCommand, result: &CompileResult) {
+    if result.exit_code != 0 {
+        return;
+    }
+    let Some(output_pdf) = &result.output_pdf else {
+        return;
+    };
+    let page_count = result
+        .stable_compile_state
+        .as_ref()
+        .map_or(0, |state| state.page_count);
+    println!(
+        "{} -> {} ({} page{}, {} ms)",
+        command.file.display(),
+        output_pdf.display(),
+        page_count,
+        if page_count == 1 { "" } else { "s" },
+        result.stage_timing.total().as_millis()
+    );
+}
+
 fn handle_watch(command: &WatchCommand) -> i32 {
     eprintln!("watching {}", command.compile.file.display());
     eprintln!("press Ctrl+C to stop");
@@ -365,6 +386,7 @@ fn handle_preview(command: &CompileCommand) -> i32 {
 
             println!("{}", bootstrap.document_url);
             println!("{}", bootstrap.events_url);
+            print_preview_initial_compile_success_summary(command, result);
 
             let svc = Arc::clone(&callback_service);
             callback_transport.set_view_state_handler(Arc::new(move |session_id, update| {

--- a/crates/ferritex-cli/tests/e2e_compile.rs
+++ b/crates/ferritex-cli/tests/e2e_compile.rs
@@ -3123,11 +3123,28 @@ fn preview_reuses_successful_initial_compile_when_starting_watch_loop() {
     stdout
         .read_line(&mut events_url)
         .expect("read preview events URL");
+    let mut success_summary = String::new();
+    stdout
+        .read_line(&mut success_summary)
+        .expect("read preview initial compile success summary");
 
     let document_url = document_url.trim().to_string();
     let events_url = events_url.trim().to_string();
+    let success_summary = success_summary.trim().to_string();
     assert!(document_url.starts_with("http://127.0.0.1:"));
     assert!(events_url.starts_with("ws://127.0.0.1:"));
+    assert!(
+        success_summary.contains(tex_file.to_str().expect("utf-8 path")),
+        "summary should mention the input file, got: {success_summary}"
+    );
+    assert!(
+        success_summary.contains("hello.pdf"),
+        "summary should mention the generated PDF path, got: {success_summary}"
+    );
+    assert!(
+        success_summary.contains("(1 page, ") && success_summary.ends_with(" ms)"),
+        "summary should include page count and elapsed milliseconds, got: {success_summary}"
+    );
 
     wait_until(
         || buffer_contains(&stderr_buf, "tracking 1 file"),


### PR DESCRIPTION
Closes #68

## Summary
- emit an explicit preview bootstrap compile success summary after initial compile succeeds
- cover the summary line in the preview e2e test

## Tests
- cargo test -p ferritex-cli --test e2e_compile preview_reuses_successful_initial_compile_when_starting_watch_loop -- --nocapture
- cargo test -p ferritex-cli --test e2e_compile preview_ -- --nocapture
- git diff --check

Note: cargo test -p ferritex-cli timed out after unit tests passed while running long benchmark e2e tests.