### PR TITLE
docs: align compile exit-code contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ cargo run --release -- compile hello.tex --asset-bundle tmp/bundle/FTX-ASSET-BUN
 cargo run --release -- compile hello.tex --synctex
 ```
 
-`ferritex compile` uses exit code 0 for successful compiles, 1 for warning-only
-diagnostics, and 2 for fatal diagnostics. Unsupported Unicode code points such
-as CJK characters currently emit a fatal diagnostic that identifies the
-unsupported character and exits with code 2.
+`ferritex compile` uses exit code 0 for successful compiles, including
+warning-only diagnostics, and 2 for fatal diagnostics. Unsupported Unicode code
+points such as CJK characters currently emit a fatal diagnostic that identifies
+the unsupported character and exits with code 2.
 
 ### 4. Other subcommands
 


### PR DESCRIPTION
## Summary
- Align README compile exit-code contract with existing warning-only behavior
- Preserve the documented fatal exit code 2 contract for unsupported CJK diagnostics

## Tests
- cargo test -p ferritex-cli --test e2e_compile compile_with_warnings_exits_success_and_prints_summary_including_warning_count -- --exact
- cargo test -p ferritex-cli --test e2e_compile compile_with_unsupported_cjk_character_emits_error -- --exact

Follow-up for issue #104 review finding after #154.