### PR TITLE
docs: document LSP diagnostic metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,16 @@ Minimal `publishDiagnostics` notification payload:
     "diagnostics": [
       {
         "range": {
-          "start": { "line": 0, "character": 0 },
-          "end": { "line": 0, "character": 5 }
+          "start": { "line": 2, "character": 0 },
+          "end": { "line": 2, "character": 16 }
         },
         "severity": 1,
-        "message": "Undefined control sequence"
+        "source": "ferritex",
+        "message": "unclosed environment `equation`",
+        "data": {
+          "context": "\\begin{equation}",
+          "suggestion": "insert \\end{equation} before the document ends"
+        }
       }
     ]
   }


### PR DESCRIPTION
## Summary
- Update README LSP publishDiagnostics example to show source and diagnostic data metadata.
- Align the example with the existing LSP diagnostic payload covered by the focused e2e test.

## Tests
- cargo test -p ferritex-cli lsp_diagnostics_include_source_and_context --test e2e_compile -- --exact

Closes #166