### PR TITLE
fix: gate partition multisecond speedup proof

### DIFF
--- a/crates/ferritex-cli/tests/bench_bundle_bootstrap.rs
+++ b/crates/ferritex-cli/tests/bench_bundle_bootstrap.rs
@@ -444,8 +444,11 @@ fn partition_bench_multicol_article_output_identity_across_jobs_1_and_jobs_4() {
 /// It uses `--reproducible` to reduce metadata jitter, prints per-case
 /// evidence, and hard-fails unless every heavy case preserves output identity
 /// while still achieving a measurable speedup for both the book and article
-/// partition corpora.
+/// partition corpora. It is ignored by default because the strict no-cache
+/// multi-run proof is intentionally long-running; use `--ignored` when
+/// recording explicit REQ-FUNC-032 evidence.
 #[test]
+#[ignore = "REQ-FUNC-032 strict no-cache multi-second speedup proof; run explicitly via --ignored"]
 fn partition_bench_multisecond_speedup_evidence() {
     let has_benchmark_precondition =
         std::thread::available_parallelism().is_ok_and(|n| n.get() >= 4);


### PR DESCRIPTION
Closes #207

## Summary
- Mark the strict no-cache multi-second partition speedup proof as ignored by default.
- Keep the bounded partition docs protocol test in the normal cargo test gate.

## Tests
- cargo test -p ferritex-cli --test bench_bundle_bootstrap partition_bench_multisecond_speedup_evidence -- --exact --nocapture
- cargo test -p ferritex-cli --test bench_bundle_bootstrap partition_bench_docs_protocol_median_and_timing_proof -- --exact --nocapture
- cargo test --workspace (timed out after 900s while running partition_bench_output_identity_across_jobs_1_and_jobs_4; Issue #207 focused test was ignored before that)
- cargo fmt --check (failed on pre-existing formatting differences outside this diff)